### PR TITLE
Drop creditor requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ cd flow-demo-app
 bundle install
 
 export GC_ACCESS_TOKEN=...
-export GC_CREDITOR_ID=...
 bundle exec shotgun app.rb
 ```
 

--- a/app.json
+++ b/app.json
@@ -5,14 +5,8 @@
   "logo": "https://gocardless.com/images/logos/gocardless-square.png",
   "success_url": "/",
   "env": {
-    "GC_API_KEY_ID": {
-      "description": "GoCardless API key"
-    },
-    "GC_API_SECRET": {
-      "description": "GoCardless API secret"
-    },
-    "GC_CREDITOR_ID": {
-      "description": "GoCardless Creditor ID"
+    "GC_ACCESS_TOKEN": {
+      "description": "GoCardless access token"
     }
   }
 }

--- a/app.rb
+++ b/app.rb
@@ -13,7 +13,6 @@ require 'pry'
 
 # Load Environment Variables
 Prius.load(:gc_access_token)
-Prius.load(:gc_creditor_id)
 
 PACKAGE_PRICES = {
   "bronze" => { "GBP" => 100, "EUR" => 130 },
@@ -72,9 +71,6 @@ post '/purchase' do
     session_token: session[:token],
     success_redirect_url: success_url,
     scheme: params[:scheme],
-    links: {
-      creditor: Prius.get(:gc_creditor_id)
-    }
   })
   redirect redirect_flow.redirect_url
 end
@@ -86,9 +82,6 @@ get '/payment_complete' do
   price = PACKAGE_PRICES.fetch(package)
 
   # Complete the redirect flow
-  puts session[:token]
-  puts redirect_flow_id
-
   completed_redirect_flow = settings.api_client.redirect_flows.
     complete(redirect_flow_id, params: { session_token: session[:token] })
 


### PR DESCRIPTION
We only require a creditor if your organisation manages multiple creditors. Now that's no longer the default, we can drop the requirement from this app.

(That's a really good thing, because finding your creditor ID in the dashboard is non-trivial.)